### PR TITLE
Added JetBrains Support

### DIFF
--- a/NautilusCode/program_list.py
+++ b/NautilusCode/program_list.py
@@ -34,9 +34,97 @@ progs += Program('sublime', _("Sublime"),
                  Flatpak("com.sublimetext.three"),
                  Native("subl"))
 
+progs += Program('android-studio', _('Android Studio'),
+                 Native('studio'),
+                 Flatpak('com.google.AndroidStudio'))
+
+progs += Program('aqua', _('Aqua'),
+                 Native('aqua'))
+
+progs += Program('clion', _('CLion'),
+                 Native('clion'),
+                 Flatpak('com.jetbrains.CLion'),)
+
+progs += Program('clion-eap', _('CLion (EAP)'),
+                 Native('clion-eap'))
+
+progs += Program('datagrip', _('DataGrip'),
+                 Native('datagrip'),
+                 Flatpak('com.jetbrains.DataGrip'))
+
+progs += Program('datagrip-eap', _('DataGrip (EAP)'),
+                 Native('datagrip-eap'))
+
+progs += Program('dataspell', _('DataSpell'),
+                 Native('dataspell'))
+
+progs += Program('dataspell-eap', _('DataSpell (EAP)'),
+                 Native('dataspell-eap'))
+
+progs += Program('fleet', _('Fleet'),
+                 Native('fleet'))
+
+progs += Program('goland', _('GoLand'),
+                 Native('goland'),
+                 Flatpak('com.jetbrains.GoLand'))
+
+progs += Program('goland-eap', _('GoLand (EAP)'),
+                 Native('goland-eap'))
+
+# IntelliJ IDEA has multiple editions that default to the same command but
+# prioritise the highest-paying edition. Therefore the native version has been
+# treated as a separate program due to the uncertainty around edition.
+progs += Program('idea', _('IntelliJ IDEA'),
+                 Native('idea'))
+
+progs += Program('idea-eap', _('IntelliJ IDEA (EAP)'),
+                 Native('idea-eap'))
+
+progs += Program('idea-community', _('IntelliJ IDEA Community'),
+                 Flatpak('com.jetbrains.IntelliJ-IDEA-Community'))
+
+progs += Program('idea-professional', _('IntelliJ IDEA Ultimate'),
+                 Flatpak('com.jetbrains.IntelliJ-IDEA-Ultimate'))
+
+progs += Program('mps', _('MPS'),
+                 Native('mps'))
+
 progs += Program('phpstorm', _("PhpStorm"),
                  Flatpak("com.jetbrains.PhpStorm"),
                  Native("phpstorm"))
 
 progs += Program('phpstorm-eap', _("PhpStorm (EAP)"),
                  Native("phpstorm-eap"))
+
+# PyCharm has multiple editions that default to the same command but
+# prioritise the highest-paying edition. Therefore the native version has been
+# treated as a separate program due to the uncertainty around edition.
+progs += Program('pycharm', _('PyCharm'),
+		 Native('pycharm'))
+
+progs += Program('pycharm-eap', _('PyCharm (EAP)'),
+		 Native('pycharm-eap'))
+
+progs += Program('pycharm-professional', _('PyCharm Professional'),
+		 Flatpak('com.jetbrains.PyCharm-Professional'))
+
+progs += Program('pycharm-community', _('PyCharm Community'),
+		 Flatpak('com.jetbrains.PyCharm-Community'))
+
+progs += Program('rider', _('Rider'),
+                 Native('rider'),
+                 Flatpak('com.jetbrains.Rider'))
+
+progs += Program('rubymine', _('RubyMine'),
+                 Native('rubymine'),
+                 Flatpak('com.jetbrains.RubyMine'))
+
+progs += Program('rubymine-eap', _('RubyMine (EAP)'),
+                 Native('rubymine-eap'))
+
+progs += Program('webstorm', _('WebStorm'),
+                 Native('webstorm'),
+                 Flatpak('com.jetbrains.WebStorm'))
+
+progs += Program('webstorm-eap', _('WebStorm (EAP)'),
+                 Native('webstorm-eap'))

--- a/README.md
+++ b/README.md
@@ -35,7 +35,20 @@ ninja uninstall -C build
   - VSCodium
   - Code - OSS
 - Sublime Text
+- Android Studio
+- Aqua
+- CLion
+- DataGrip
+- DataSpell
+- Fleet
+- GoLand
+- IntelliJ
+- MPS
 - PhpStorm
+- PyCharm
+- Rider
+- RubyMine
+- WebStorm
 
 ### Request support for your favorite IDE or Code Editor
 You can [create a GitHub issue](https://github.com/realmazharhussain/nautilus-code/issues/new) to request support for your favorite IDE or Code Editor.


### PR DESCRIPTION
Added native and flatpak support for Jetbrains IDEs.

All of these apply to installations via Jetbrains Toolbox as well, since it creates links for the native commands (resolves https://github.com/realmazharhussain/nautilus-code/issues/9).

Every new IDE was installed and tested (both Native and Flatpak) to confirm that they open projects as expected and don't require additional arguments. Language support will still need updating with all the new IDEs, however I also noticed that many of the translation files already had incorrect line numbers in the comments.

List of Jetbrains IDEs:

    Android Studio
    Aqua
    CLion
    DataGrip
    DataSpell
    Fleet
    GoLand
    IntelliJ
    MPS
    PhpStorm (already supported)
    PyCharm
    Rider
    RubyMine
    WebStorm