### PR TITLE
Fix: correct app title for Zed context menu integration

### DIFF
--- a/NautilusCode/program_list.py
+++ b/NautilusCode/program_list.py
@@ -142,7 +142,7 @@ progs += Program('webstorm-eap', _('WebStorm (EAP)'),
                  Native('webstorm-eap'))
 
 progs += Program('zed', _('Zed'),
-                 Native('zed', 'zeditor', 'zedit'),
+                 Native('zed', 'zedit', 'zeditor', 'zed-editor'),
                  Flatpak('dev.zed.Zed'))
 
 progs += Program('zed-preview', _('Zed (Preview)'),


### PR DESCRIPTION
Previous name wasn't displaying in context menu due to incompatibility with recent Zed updates. Changed to new application name that is properly recognized.