### PR TITLE
Add JetBrains Toolbox support (and Air)

### DIFF
--- a/NautilusCode/program_list.py
+++ b/NautilusCode/program_list.py
@@ -1,6 +1,6 @@
 from gettext import gettext as _
 
-from .types import ProgramList, Program, Native, Flatpak
+from .types import ProgramList, Program, Native, Flatpak, Toolbox
 
 progs = ProgramList()
 
@@ -112,7 +112,8 @@ progs += Program('phpstorm-eap', _("PhpStorm (EAP)"),
 # prioritise the highest-paying edition. Therefore the native version has been
 # treated as a separate program due to the uncertainty around edition.
 progs += Program('pycharm', _('PyCharm'),
-		 Native('pycharm'))
+		 Native('pycharm'),
+		 Toolbox('PyCharm', 'PyCharm-P', 'PyCharm-C'))
 
 progs += Program('pycharm-eap', _('PyCharm (EAP)'),
 		 Native('pycharm-eap'))

--- a/NautilusCode/program_list.py
+++ b/NautilusCode/program_list.py
@@ -47,6 +47,10 @@ progs += Program('android-studio', _('Android Studio'),
                  Native('studio'),
                  Flatpak('com.google.AndroidStudio'))
 
+progs += Program('air', _('Air'),
+                 Native('air'),
+                 Toolbox('Air'))
+
 progs += Program('aqua', _('Aqua'),
                  Native('aqua'),
                  Toolbox('Aqua'))

--- a/NautilusCode/program_list.py
+++ b/NautilusCode/program_list.py
@@ -48,11 +48,13 @@ progs += Program('android-studio', _('Android Studio'),
                  Flatpak('com.google.AndroidStudio'))
 
 progs += Program('aqua', _('Aqua'),
-                 Native('aqua'))
+                 Native('aqua'),
+                 Toolbox('Aqua'))
 
 progs += Program('clion', _('CLion'),
                  Native('clion'),
-                 Flatpak('com.jetbrains.CLion'),)
+                 Flatpak('com.jetbrains.CLion'),
+                 Toolbox('CLion'))
 
 progs += Program('clion-eap', _('CLion (EAP)'),
                  Native('clion-eap'))
@@ -62,23 +64,27 @@ progs += Program('cursor', _('Cursor'),
 
 progs += Program('datagrip', _('DataGrip'),
                  Native('datagrip'),
-                 Flatpak('com.jetbrains.DataGrip'))
+                 Flatpak('com.jetbrains.DataGrip'),
+                 Toolbox('DataGrip'))
 
 progs += Program('datagrip-eap', _('DataGrip (EAP)'),
                  Native('datagrip-eap'))
 
 progs += Program('dataspell', _('DataSpell'),
-                 Native('dataspell'))
+                 Native('dataspell'),
+                 Toolbox('DataSpell'))
 
 progs += Program('dataspell-eap', _('DataSpell (EAP)'),
                  Native('dataspell-eap'))
 
 progs += Program('fleet', _('Fleet'),
-                 Native('fleet'))
+                 Native('fleet'),
+                 Toolbox('Fleet'))
 
 progs += Program('goland', _('GoLand'),
                  Native('goland'),
-                 Flatpak('com.jetbrains.GoLand'))
+                 Flatpak('com.jetbrains.GoLand'),
+                 Toolbox('GoLand'))
 
 progs += Program('goland-eap', _('GoLand (EAP)'),
                  Native('goland-eap'))
@@ -86,8 +92,11 @@ progs += Program('goland-eap', _('GoLand (EAP)'),
 # IntelliJ IDEA has multiple editions that default to the same command but
 # prioritise the highest-paying edition. Therefore the native version has been
 # treated as a separate program due to the uncertainty around edition.
+# Toolbox uses one toolId per product and cannot cleanly separate EAP from
+# stable, so only the stable entry carries the Toolbox toolId.
 progs += Program('idea', _('IntelliJ IDEA'),
-                 Native('idea'))
+                 Native('idea'),
+                 Toolbox('IntelliJ-IDEA', 'IntelliJIdea', 'IDEA', 'IDEA-U', 'IDEA-C'))
 
 progs += Program('idea-eap', _('IntelliJ IDEA (EAP)'),
                  Native('idea-eap'))
@@ -99,11 +108,13 @@ progs += Program('idea-professional', _('IntelliJ IDEA Ultimate'),
                  Flatpak('com.jetbrains.IntelliJ-IDEA-Ultimate'))
 
 progs += Program('mps', _('MPS'),
-                 Native('mps'))
+                 Native('mps'),
+                 Toolbox('MPS'))
 
 progs += Program('phpstorm', _("PhpStorm"),
                  Flatpak("com.jetbrains.PhpStorm"),
-                 Native("phpstorm"))
+                 Native("phpstorm"),
+                 Toolbox('PhpStorm'))
 
 progs += Program('phpstorm-eap', _("PhpStorm (EAP)"),
                  Native("phpstorm-eap"))
@@ -112,32 +123,43 @@ progs += Program('phpstorm-eap', _("PhpStorm (EAP)"),
 # prioritise the highest-paying edition. Therefore the native version has been
 # treated as a separate program due to the uncertainty around edition.
 progs += Program('pycharm', _('PyCharm'),
-		 Native('pycharm'),
-		 Toolbox('PyCharm', 'PyCharm-P', 'PyCharm-C'))
+                 Native('pycharm'),
+                 Toolbox('PyCharm', 'PyCharm-P', 'PyCharm-C'))
 
 progs += Program('pycharm-eap', _('PyCharm (EAP)'),
-		 Native('pycharm-eap'))
+                 Native('pycharm-eap'))
 
 progs += Program('pycharm-professional', _('PyCharm Professional'),
-		 Flatpak('com.jetbrains.PyCharm-Professional'))
+                 Flatpak('com.jetbrains.PyCharm-Professional'))
 
 progs += Program('pycharm-community', _('PyCharm Community'),
-		 Flatpak('com.jetbrains.PyCharm-Community'))
+                 Flatpak('com.jetbrains.PyCharm-Community'))
 
 progs += Program('rider', _('Rider'),
                  Native('rider'),
-                 Flatpak('com.jetbrains.Rider'))
+                 Flatpak('com.jetbrains.Rider'),
+                 Toolbox('Rider'))
 
 progs += Program('rubymine', _('RubyMine'),
                  Native('rubymine'),
-                 Flatpak('com.jetbrains.RubyMine'))
+                 Flatpak('com.jetbrains.RubyMine'),
+                 Toolbox('RubyMine'))
 
 progs += Program('rubymine-eap', _('RubyMine (EAP)'),
                  Native('rubymine-eap'))
 
+progs += Program('rustrover', _('RustRover'),
+                 Native('rustrover'),
+                 Flatpak('com.jetbrains.RustRover'),
+                 Toolbox('RustRover'))
+
+progs += Program('rustrover-eap', _('RustRover (EAP)'),
+                 Native('rustrover-eap'))
+
 progs += Program('webstorm', _('WebStorm'),
                  Native('webstorm'),
-                 Flatpak('com.jetbrains.WebStorm'))
+                 Flatpak('com.jetbrains.WebStorm'),
+                 Toolbox('WebStorm'))
 
 progs += Program('webstorm-eap', _('WebStorm (EAP)'),
                  Native('webstorm-eap'))

--- a/NautilusCode/types.py
+++ b/NautilusCode/types.py
@@ -63,8 +63,11 @@ class Native (Package):
 
 class Toolbox (Package):
     type_name = _('Toolbox')
-    state_file = os.path.join(user_data_dir, 'JetBrains', 'Toolbox', 'state.json')
+    toolbox_dir = os.path.join(user_data_dir, 'JetBrains', 'Toolbox')
+    state_file = os.path.join(toolbox_dir, 'state.json')
+    settings_file = os.path.join(toolbox_dir, '.settings.json')
     _tools = None
+    _scripts_dir = None
 
     @classmethod
     def _load_tools (cls):
@@ -75,6 +78,28 @@ class Toolbox (Package):
             except (OSError, ValueError):
                 cls._tools = []
         return cls._tools
+
+    @classmethod
+    def scripts_dir (cls):
+        '''Directory where Toolbox writes the shell-script launchers it adds
+           to PATH. The location is user-configurable in Toolbox settings and
+           defaults to the "scripts" folder next to state.json.'''
+        if cls._scripts_dir is None:
+            cls._scripts_dir = os.path.normpath(cls._read_scripts_location())
+        return cls._scripts_dir
+
+    @classmethod
+    def _read_scripts_location (cls):
+        '''Read the configured shell-scripts location from Toolbox settings,
+           falling back to the default "scripts" folder next to state.json
+           when the settings file is missing, unreadable, or unset.'''
+        default = os.path.join(cls.toolbox_dir, 'scripts')
+        try:
+            with open(cls.settings_file, encoding='utf-8') as f:
+                settings = json.load(f)
+        except (OSError, ValueError):
+            return default
+        return (settings.get('shell_scripts') or {}).get('location') or default
 
     def __init__ (self, *tool_ids):
       self.tool_ids = tool_ids
@@ -95,6 +120,30 @@ class Toolbox (Package):
     @property
     def is_installed (self) -> bool:
         return bool(self.launch_command)
+
+    def is_shadowed_by (self, native) -> bool:
+        '''Whether the given installed Native package actually refers to this
+           same Toolbox installation. Toolbox adds shell-script launchers to
+           PATH, so `Native` detection happily resolves e.g. `pycharm` to a
+           Toolbox-generated script. In that case both packages launch the
+           exact same IDE and should not be listed twice.'''
+        if not (self.is_installed and native and native.is_installed):
+            return False
+
+        native_path = os.path.normpath(native.cmd_path)
+
+        # The resolved Native command lives inside the Toolbox scripts folder,
+        # i.e. it *is* a Toolbox-generated launcher.
+        if os.path.dirname(native_path) == self.scripts_dir():
+            return True
+
+        # The Native command and the Toolbox launcher ultimately resolve to the
+        # very same executable (e.g. a symlink pointing straight at the app).
+        if (os.path.realpath(native_path)
+                == os.path.realpath(self.launch_command)):
+            return True
+
+        return False
 
     def __str__ (self):
         lines = super().__str__().splitlines()
@@ -173,6 +222,24 @@ class Program:
         for pkg in self.packages:
             if pkg.is_installed:
                 pkgs.append(pkg)
+        return self._dedupe(pkgs)
+
+    @staticmethod
+    def _dedupe (pkgs):
+        '''Remove packages that are merely a different "view" of an install
+           already represented by another package, so the same IDE is not
+           offered twice in the menu.
+
+           JetBrains Toolbox is the main offender: it drops launcher scripts
+           into a directory on PATH, so a Toolbox install is detected both as
+           `Toolbox` (via state.json) and as `Native` (via that script). When
+           that happens we keep `Native` and drop the `Toolbox` duplicate, which
+           effectively turns Toolbox into a fallback that only shows up when its
+           launcher is not on PATH.'''
+        native = next((p for p in pkgs if isinstance(p, Native)), None)
+        if native:
+            pkgs = [p for p in pkgs
+                    if not (isinstance(p, Toolbox) and p.is_shadowed_by(native))]
         return pkgs
 
     def add (self, pkg):

--- a/NautilusCode/types.py
+++ b/NautilusCode/types.py
@@ -1,3 +1,4 @@
+import json
 import os
 from gettext import gettext as _
 
@@ -57,6 +58,50 @@ class Native (Package):
           lines.insert(-1, f"  command = {os.path.basename(self.cmd_path)}")
         elif self.commands:
           lines.insert(-1, f"  command(s) = " + ', '.join(self.commands))
+        return  '\n'.join(lines)
+
+
+class Toolbox (Package):
+    type_name = _('Toolbox')
+    state_file = os.path.join(user_data_dir, 'JetBrains', 'Toolbox', 'state.json')
+    _tools = None
+
+    @classmethod
+    def _load_tools (cls):
+        if cls._tools is None:
+            try:
+                with open(cls.state_file, encoding='utf-8') as f:
+                    cls._tools = json.load(f).get('tools', []) or []
+            except (OSError, ValueError):
+                cls._tools = []
+        return cls._tools
+
+    def __init__ (self, *tool_ids):
+      self.tool_ids = tool_ids
+      self.launch_command = ''
+      for tool in self._load_tools():
+        if tool.get('toolId') in tool_ids:
+          cmd = tool.get('launchCommand', '')
+          if cmd and os.path.exists(cmd):
+            self.launch_command = cmd
+            break
+
+    @property
+    def run_command (self) -> tuple[str]:
+        '''The command that should be executed in order to
+           run a program using this type of package'''
+        return (self.launch_command,)
+
+    @property
+    def is_installed (self) -> bool:
+        return bool(self.launch_command)
+
+    def __str__ (self):
+        lines = super().__str__().splitlines()
+        if self.launch_command:
+          lines.insert(-1, f"  command = {self.launch_command}")
+        elif self.tool_ids:
+          lines.insert(-1, f"  tool_id(s) = " + ', '.join(self.tool_ids))
         return  '\n'.join(lines)
 
 

--- a/NautilusCode/types.py
+++ b/NautilusCode/types.py
@@ -18,10 +18,30 @@ class NamedList (dict):
         return self.keys()
 
 
+class Priority:
+    '''Named priority levels for package deduplication.  Higher value wins on
+     an identity collision, so the base default (FALLBACK) is the lowest and
+     any package type added without an explicit priority safely loses.  Values
+     are spaced so new levels can be slotted in between without renumbering.'''
+    FALLBACK = 0
+    NORMAL = 10
+    PREFERRED = 20
+
+
 class Package:
     run_command: tuple[str]
     is_installed: bool
     type_name = _('Unknown')
+    priority = Priority.FALLBACK
+
+    @property
+    def identity (self):
+        '''The set of values that identify the actual program being launched.
+           Each package describes only itself; two installed packages are
+           considered the same install when their identity sets intersect.  On
+           a collision the one with the higher priority wins and the other is
+           dropped by _dedupe.  Return an empty set to opt out of dedup.'''
+        return frozenset()
 
     @property
     def type_name_raw (self):
@@ -33,6 +53,7 @@ class Package:
 
 class Native (Package):
     type_name = _('Native')
+    priority = Priority.PREFERRED
     cmd_path = ''
 
     def __init__ (self, *commands):
@@ -51,6 +72,15 @@ class Native (Package):
     @property
     def is_installed (self):
         return bool(self.cmd_path)
+
+    @property
+    def identity (self):
+        '''The real executable this command resolves to.  Knows nothing about
+           any other package type; it is up to e.g. Toolbox to declare that it
+           also owns a launcher on PATH that resolves here.'''
+        if not self.cmd_path:
+            return frozenset()
+        return frozenset({os.path.realpath(self.cmd_path)})
 
     def __str__ (self):
         lines = super().__str__().splitlines()
@@ -104,11 +134,13 @@ class Toolbox (Package):
     def __init__ (self, *tool_ids):
       self.tool_ids = tool_ids
       self.launch_command = ''
+      self.install_location = ''
       for tool in self._load_tools():
         if tool.get('toolId') in tool_ids:
           cmd = tool.get('launchCommand', '')
           if cmd and os.path.exists(cmd):
             self.launch_command = cmd
+            self.install_location = tool.get('installLocation', '')
             break
 
     @property
@@ -121,29 +153,43 @@ class Toolbox (Package):
     def is_installed (self) -> bool:
         return bool(self.launch_command)
 
-    def is_shadowed_by (self, native) -> bool:
-        '''Whether the given installed Native package actually refers to this
-           same Toolbox installation. Toolbox adds shell-script launchers to
-           PATH, so `Native` detection happily resolves e.g. `pycharm` to a
-           Toolbox-generated script. In that case both packages launch the
-           exact same IDE and should not be listed twice.'''
-        if not (self.is_installed and native and native.is_installed):
-            return False
+    @property
+    def identity (self):
+        '''The launcher executable plus every launcher Toolbox dropped on PATH
+           that points at this install.  By declaring the PATH launchers it
+           owns, a Native command that resolves to one of them collides with
+           this entry without Native needing to know Toolbox exists.'''
+        if not self.launch_command:
+            return frozenset()
+        ids = {os.path.realpath(self.launch_command)}
+        ids.update(self._owned_scripts())
+        return frozenset(ids)
 
-        native_path = os.path.normpath(native.cmd_path)
-
-        # The resolved Native command lives inside the Toolbox scripts folder,
-        # i.e. it *is* a Toolbox-generated launcher.
-        if os.path.dirname(native_path) == self.scripts_dir():
-            return True
-
-        # The Native command and the Toolbox launcher ultimately resolve to the
-        # very same executable (e.g. a symlink pointing straight at the app).
-        if (os.path.realpath(native_path)
-                == os.path.realpath(self.launch_command)):
-            return True
-
-        return False
+    def _owned_scripts (self):
+        '''Real paths of launchers in the Toolbox scripts dir that start this
+           install.  Toolbox writes either a symlink into the install dir or a
+           wrapper shell script that execs the launchCommand, so both forms are
+           recognised here.'''
+        owned = set()
+        install = os.path.realpath(self.install_location) if self.install_location else ''
+        try:
+            entries = list(os.scandir(self.scripts_dir()))
+        except OSError:
+            return owned
+        for entry in entries:
+            real = os.path.realpath(entry.path)
+            # Symlink launcher resolving into this install dir.
+            if install and (real == install or real.startswith(install + os.sep)):
+                owned.add(real)
+                continue
+            # Wrapper script launcher that execs this install's launchCommand.
+            try:
+                with open(entry.path, encoding='utf-8', errors='ignore') as f:
+                    if self.launch_command in f.read():
+                        owned.add(real)
+            except OSError:
+                pass
+        return owned
 
     def __str__ (self):
         lines = super().__str__().splitlines()
@@ -156,6 +202,7 @@ class Toolbox (Package):
 
 class Flatpak (Package):
     type_name = _('Flatpak')
+    priority = Priority.FALLBACK
     flatpak_path = GLib.find_program_in_path('flatpak') or ''
     flatpak_bin_dirs = None
 
@@ -200,6 +247,12 @@ class Flatpak (Package):
 
         return False
 
+    @property
+    def identity (self):
+        # Flatpak apps are sandboxed; their identity can never collide with a
+        # filesystem path used by Native or Toolbox packages.
+        return frozenset({('flatpak', self.app_id)})
+
     def __str__ (self):
         lines = super().__str__().splitlines()
         lines.insert(-1, f"  app_id = {self.app_id}")
@@ -230,17 +283,21 @@ class Program:
            already represented by another package, so the same IDE is not
            offered twice in the menu.
 
-           JetBrains Toolbox is the main offender: it drops launcher scripts
-           into a directory on PATH, so a Toolbox install is detected both as
-           `Toolbox` (via state.json) and as `Native` (via that script). When
-           that happens we keep `Native` and drop the `Toolbox` duplicate, which
-           effectively turns Toolbox into a fallback that only shows up when its
-           launcher is not on PATH.'''
-        native = next((p for p in pkgs if isinstance(p, Native)), None)
-        if native:
-            pkgs = [p for p in pkgs
-                    if not (isinstance(p, Toolbox) and p.is_shadowed_by(native))]
-        return pkgs
+           Each Package subclass declares an `identity` set (the things it
+           launches) and a `priority` (which representation wins on a
+           collision).  Two installed packages are duplicates when their
+           identity sets intersect; the lower-priority one is dropped.  An
+           empty identity set never collides with anything.'''
+        kept = []
+        kept_identities = []
+        for pkg in sorted(pkgs, key=lambda p: -p.priority):
+            ident = pkg.identity
+            if ident and any(ident & seen for seen in kept_identities):
+                continue
+            kept.append(pkg)
+            if ident:
+                kept_identities.append(ident)
+        return [p for p in pkgs if p in kept]
 
     def add (self, pkg):
         self.packages[pkg.type_name_raw] = pkg

--- a/NautilusCode/types.py
+++ b/NautilusCode/types.py
@@ -33,6 +33,17 @@ class Package:
     is_installed: bool
     type_name = _('Unknown')
     priority = Priority.FALLBACK
+    show_type_name = True
+
+    def menu_label (self, program_name, *, disambiguate=False):
+        '''Build the menu label for launching `program_name` via this package.
+           When `disambiguate` is set (more than one install of the program is
+           shown) and this package type wants it, the type name is appended so
+           the entries can be told apart.'''
+        label = _('Open in %s') % program_name
+        if disambiguate and self.show_type_name:
+            label += f' ({self.type_name})'
+        return label
 
     @property
     def identity (self):
@@ -54,6 +65,7 @@ class Package:
 class Native (Package):
     type_name = _('Native')
     priority = Priority.PREFERRED
+    show_type_name = False
     cmd_path = ''
 
     def __init__ (self, *commands):
@@ -341,9 +353,7 @@ class ProgramList (NamedList):
 
                 name = id_prefix + program.id
                 command = [*pkg.run_command, *program.arguments, path]
-                label = _('Open in %s') % program.name
-                if include_type_name:
-                    label += f' ({pkg.type_name})'
+                label = pkg.menu_label(program.name, disambiguate=include_type_name)
 
                 item = Nautilus.MenuItem.new(name, label)
                 item.connect('activate', self._activate_item, command)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ ninja uninstall -C build
   - Code - OSS
 - Sublime Text
 - Android Studio
+- Air
 - Aqua
 - CLion
 - Cursor


### PR DESCRIPTION
Hi @realmazharhussain ,

Thanks for making this extension, I use it daily.

I have added some improvements in this PR.

It adds detection for JetBrains IDEs installed via JetBrains Toolbox, which were
previously not shown in the Nautilus menu as mentioned in https://github.com/realmazharhussain/nautilus-code/issues/29 

 A new `Toolbox` package type reads
Toolbox's `state.json` to locate installed tools and their launch commands, and
is wired up for the supported JetBrains IDEs. 

I also added support for Jetbrains Air, which is currently in beta test.

To avoid showing the same IDE twice (Toolbox writes launcher scripts onto
`PATH`, so an install can be detected as both `Native` and `Toolbox`), package
detection now uses identity sets with priority levels, deduplicating within a
program and keeping the preferred entry.

## Deduplication issue
Deduplication is per-program, so the *same* installed IDE surfaced under two different
programs (e.g. a Toolbox-adopted PyCharm EAP also detected natively) can still
appear twice. This happens on Arch linux. I haven't tested with other distros, so some testing of this plus Flatpak installs will be appreciated. 

Thanks!  
